### PR TITLE
rss.go: Stop when encountering an old date

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -92,7 +92,7 @@ func (f Feed) FilterEntries(history []string, numOfEntries int) Feed {
 			break
 		}
 		if stringInSlice(history, e.ID) {
-			continue
+			break
 		}
 		entries = append(entries, e)
 		count++


### PR DESCRIPTION
When filtering down the entries that will get posted, break instead of continuing when encountering an old date. This stops old entries from getting posted when someone deletes an entry.